### PR TITLE
Update README URLs based on HTTP redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Inspired by [this project on Dribbble](https://dribbble.com/shots/2702517-Review
 
 ## Installation
 
-####[CocoaPods](http://cocoapods.org)
+####[CocoaPods](https://cocoapods.org/)
 
 ```ruby
 pod 'ColorMatchTabs', '~> 1.0'


### PR DESCRIPTION
Cause `https` rocks

Created with https://github.com/dkhamsing/frankenstein
### Corrected URLs

| Was | Now |
| --- | --- |
| http://cocoapods.org | https://cocoapods.org/ |
